### PR TITLE
Added file size validation

### DIFF
--- a/src/public/includes/js/profile.js
+++ b/src/public/includes/js/profile.js
@@ -42,6 +42,8 @@ btnSaveUserDetails.addEventListener('click', (event) => {
     if (xmlhttp.readyState === XMLHTTPREQUEST_STATUS_DONE) {
       if (xmlhttp.status === HTTP_OK) {
         swal('Saved!', '', 'success');
+      } else if (xmlhttp.status === 413) {
+        swal('Too Large Request', 'The request was too large.', 'error');
       } else {
         showErrorMessage('Error updating user details.');
       }
@@ -256,6 +258,8 @@ function showErrorMessage(message) {
   swal('Error', message, 'error');
 }
 
+const profilePictureMaximumSizeInMB = 1.5;
+
 /**
  * Add click event listener to open a file selector
  * to let the user upload a profile picture.
@@ -271,12 +275,29 @@ userProfilePicture.addEventListener('click', (event) => {
     fileSelector.click();
   }).then((file) => {
     if (file && file.name) {
-      fileURL = URL.createObjectURL(file);
-      userProfilePicture.src = fileURL;
-      generateDataURL(file);
+      if (isFileSizeValid(file, profilePictureMaximumSizeInMB)) {
+        userProfilePicture.src = URL.createObjectURL(file);
+        generateDataURL(file);
+      } else {
+        swal('File too Large',
+            `The file must be a maximum of ${profilePictureMaximumSizeInMB}MB.`,
+            'warning');
+      }
     }
   });
 });
+
+/**
+ * Checks if the file size is within the specified maximum size in MB.
+ * @param {File} file - The file to be checked.
+ * @param {number} fileMaximumSizeInMB - The maximum allowed file size in megabytes.
+ * @return {boolean} - Returns true if the file size is within the limit, otherwise false.
+ */
+function isFileSizeValid(file, fileMaximumSizeInMB) {
+  if (fileMaximumSizeInMB <= 0) return false;
+  const maxSizeInBytes = fileMaximumSizeInMB * 1048576; // 1MB = 1048576 bytes
+  return file.size <= maxSizeInBytes;
+}
 
 /**
  * Creates a new file selector.


### PR DESCRIPTION
### Problem
- The current implementation allows users to upload profile pictures larger than 1.5MB, leading to a `413 Payload Too Large` error from the API when the file size exceeds this limit. This pull request addresses the need for client-side validation to prevent uploading files that are too large, thus reducing unnecessary API requests and improving the user experience.

### Solution
- Added client-side validation to check that the uploaded profile picture does not exceed 1.5MB before generating the Base64 representation.
- Updated the code to display a user-friendly error message if the uploaded file exceeds the 1.5MB limit, informing the user about the maximum allowable file size.
- Enhanced the upload logic to ensure the file size validation is consistent across different browsers.

### How To Test

1. Click on the profile picture upload area.
2. Select an image larger than 1.5MB.
3. Verify that an error message appears stating that the file exceeds the 1.5MB limit and the upload does not proceed.
4. Select an image under 1.5MB.
5. Confirm that the image is uploaded successfully and the profile picture is displayed.
6. Repeat the test across different browsers to ensure consistent behavior.

### Fixes 
- #58 