### PR TITLE
Add statistics panel to dashboard for key blood sugar insights

### DIFF
--- a/src/public/diary.html
+++ b/src/public/diary.html
@@ -477,6 +477,8 @@
     crossorigin="anonymous"></script>
     <!-- FILTER GLUCOSE DATA -->
     <script src="./includes/js/filterGlucoseData.js" defer></script>
+    <!-- STATISTICS -->
+    <script src="./includes/js/statistics.js" defer></script>
     <!-- FILL DIARY TABLE -->
     <script src="./includes/js/diary.js" defer></script>
     <!-- NEW ENTRY -->

--- a/src/public/home.html
+++ b/src/public/home.html
@@ -173,7 +173,7 @@
                 <div class="statistics-card">
                   <div class="statistics-card-header">                  
                     <span class="statistics-card-title">
-                      <span data-feather="droplet" class="statistics-card-icon"></span>Blood sugar deviation
+                      <span data-feather="bar-chart" class="statistics-card-icon"></span>Blood sugar deviation
                     </span>
                   </div>
                   <div class="statistics-card-content">
@@ -191,7 +191,7 @@
                 <div class="statistics-card">
                   <div class="statistics-card-header">                  
                     <span class="statistics-card-title">
-                      <span data-feather="droplet" class="statistics-card-icon"></span>Total hypos
+                      <span data-feather="arrow-down" class="statistics-card-icon"></span>Total hypos
                     </span>
                   </div>
                   <div class="statistics-card-content">
@@ -209,7 +209,7 @@
                 <div class="statistics-card">
                   <div class="statistics-card-header">                  
                     <span class="statistics-card-title">
-                      <span data-feather="droplet" class="statistics-card-icon"></span>Total hypers
+                      <span data-feather="arrow-up" class="statistics-card-icon"></span>Total hypers
                     </span>
                   </div>
                   <div class="statistics-card-content">

--- a/src/public/home.html
+++ b/src/public/home.html
@@ -155,7 +155,7 @@
                 <div class="statistics-card">
                   <div class="statistics-card-header">                  
                     <span class="statistics-card-title">
-                      <span data-feather="droplet" class="statistics-card-icon"></span>Average Blood sugar
+                      <span data-feather="droplet" class="statistics-card-icon"></span>Average blood sugar
                     </span>
                   </div>
                   <div class="statistics-card-content">
@@ -191,7 +191,7 @@
                 <div class="statistics-card">
                   <div class="statistics-card-header">                  
                     <span class="statistics-card-title">
-                      <span data-feather="droplet" class="statistics-card-icon"></span>Total Hypos
+                      <span data-feather="droplet" class="statistics-card-icon"></span>Total hypos
                     </span>
                   </div>
                   <div class="statistics-card-content">
@@ -209,7 +209,7 @@
                 <div class="statistics-card">
                   <div class="statistics-card-header">                  
                     <span class="statistics-card-title">
-                      <span data-feather="droplet" class="statistics-card-icon"></span>Total Hypers
+                      <span data-feather="droplet" class="statistics-card-icon"></span>Total hypers
                     </span>
                   </div>
                   <div class="statistics-card-content">

--- a/src/public/home.html
+++ b/src/public/home.html
@@ -111,7 +111,7 @@
           </span>
 
           <div id="panel-chart" class="invisible">
-            <div class="card ">
+            <div class="card mb-3">
               <div class="card-body">                
                 <div class="justify-content">
                   <h5 class="card-title">Report <span class="ms-2" id="search_date_range"></span></h5>
@@ -141,6 +141,89 @@
                 <div id="reports-chart"></div>
               </div>
             </div>
+            
+            <!-- STATISTICS -->
+            <div class="mb-5">                
+              <div class="justify-content">
+                <h5 class="card-title">Statistics</h5>
+              </div>
+
+              <!-- STATISTICS PANEL -->
+              <div class="statistics-panel">              
+  
+                <!-- AVERAGE BLOOD SUGAR -->
+                <div class="statistics-card">
+                  <div class="statistics-card-header">                  
+                    <span class="statistics-card-title">
+                      <span data-feather="droplet" class="statistics-card-icon"></span>Average Blood sugar
+                    </span>
+                  </div>
+                  <div class="statistics-card-content">
+                    <!-- <span class="statistics-card-dot"></span> -->
+                    <span class="statistics-card-value" id="average-value">--</span>
+                    <span class="statistics-card-unit">mg/dL</span>
+                  </div>
+                  <!-- <div class="statistics-card-footer">
+                    <span class="statistics-card-footer-text">Previous month</span>
+                    <span class="statistics-card-footer-value" id="average-previous-month-value">--</span>
+                  </div> -->
+                </div>
+
+                <!-- BLOOD SUGAR DEVIATION -->
+                <div class="statistics-card">
+                  <div class="statistics-card-header">                  
+                    <span class="statistics-card-title">
+                      <span data-feather="droplet" class="statistics-card-icon"></span>Blood sugar deviation
+                    </span>
+                  </div>
+                  <div class="statistics-card-content">
+                    <!-- <span class="statistics-card-dot"></span> -->
+                    <span class="statistics-card-value" id="deviation-value">--</span>
+                    <span class="statistics-card-unit">mg/dL</span>
+                  </div>
+                  <!-- <div class="statistics-card-footer">
+                    <span class="statistics-card-footer-text">Previous month</span>
+                    <span class="statistics-card-footer-value">38</span>
+                  </div> -->
+                </div>
+
+                <!-- TOTAL HYPOS -->
+                <div class="statistics-card">
+                  <div class="statistics-card-header">                  
+                    <span class="statistics-card-title">
+                      <span data-feather="droplet" class="statistics-card-icon"></span>Total Hypos
+                    </span>
+                  </div>
+                  <div class="statistics-card-content">
+                    <!-- <span class="statistics-card-dot"></span> -->
+                    <span class="statistics-card-value" id="hypos-value">--</span>
+                    <span class="statistics-card-unit">hypos</span>
+                  </div>
+                  <!-- <div class="statistics-card-footer">
+                    <span class="statistics-card-footer-text">Previous month</span>
+                    <span class="statistics-card-footer-value">--</span>
+                  </div> -->
+                </div>
+
+                <!-- TOTAL HYPERS -->
+                <div class="statistics-card">
+                  <div class="statistics-card-header">                  
+                    <span class="statistics-card-title">
+                      <span data-feather="droplet" class="statistics-card-icon"></span>Total Hypers
+                    </span>
+                  </div>
+                  <div class="statistics-card-content">
+                    <!-- <span class="statistics-card-dot"></span> -->
+                    <span class="statistics-card-value" id="hypers-value">--</span>
+                    <span class="statistics-card-unit">hypers</span>
+                  </div>
+                  <!-- <div class="statistics-card-footer">
+                    <span class="statistics-card-footer-text">Previous month</span>
+                    <span class="statistics-card-footer-value">--</span>
+                  </div> -->
+                </div>
+              </div> 
+            </div>            
           </div>
           <!-- End Reports -->
 

--- a/src/public/home.html
+++ b/src/public/home.html
@@ -398,6 +398,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js" 
     integrity="sha384-9MhbyIRcBVQiiC7FSd7T38oJNj2Zh+EfxS7/vjhBi4OOT78NlHSnzM31EZRWR1LZ" 
     crossorigin="anonymous"></script>
+    <!-- STATISTICS -->
+    <script src="./includes/js/statistics.js" defer></script>
     <!-- LOAD HOME -->
     <script src="./includes/js/home.js" defer></script>
     <!-- LOADS THE MARKER MEAL LIST -->

--- a/src/public/home.html
+++ b/src/public/home.html
@@ -114,7 +114,7 @@
             <div class="card mb-3">
               <div class="card-body">                
                 <div class="justify-content">
-                  <h5 class="card-title">Report <span class="ms-2" id="search_date_range"></span></h5>
+                  <h5 class="card-title"><span class="ms-2" id="search_date_range"></span></h5>
 
                   <div class="filter me-3">
                     <!-- BUTTON FILTER -->

--- a/src/public/includes/js/diary.js
+++ b/src/public/includes/js/diary.js
@@ -495,7 +495,7 @@ function fillStatisticsTable() {
   statsGlicTests.innerText = getNumberOfRegisters();
   // Average
   // eslint-disable-next-line max-len
-  const average = Math.round(totalSumBloodGlucoseValues / getNumberOfRegisters());
+  const average = (totalSumBloodGlucoseValues / getNumberOfRegisters());
   statsGlicAverage.innerText = ''.concat(average).concat(` ${UNITY_LABEL}`);
   // Standard deviation
   const standardDeviation = calculateStandardDeviation(listOfGlucoseValues);

--- a/src/public/includes/js/filterGlucoseData.js
+++ b/src/public/includes/js/filterGlucoseData.js
@@ -41,7 +41,12 @@ function getDateRangeByNumberOfWeeks(numOfWeeks) {
   const startDate = new Date();
   startDate.setDate(endDate.getDate() - numOfWeeks * 7);
 
-  const formatDate = (date) => date.toISOString().slice(0, 10);
+  const formatDate = (date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
 
   return [formatDate(startDate), formatDate(endDate)];
 }

--- a/src/public/includes/js/home.js
+++ b/src/public/includes/js/home.js
@@ -3,6 +3,11 @@ const panelChart = document.getElementById('panel-chart');
 const chartContext = document.getElementById('reports-chart');
 const panelWelcomeCenter = document.getElementById('panel-welcome-center');
 const searchDateRange = document.getElementById('search_date_range');
+// Statistics
+const averageValue = document.getElementById('average-value');
+const deviationValue = document.getElementById('deviation-value');
+const hyposValue = document.getElementById('hypos-value');
+const hypersValue = document.getElementById('hypers-value');
 
 // eslint-disable-next-line no-var
 var glucoseReadingsChart;
@@ -43,7 +48,7 @@ function getChartConfiguration() {
       },
     ],
     chart: {
-      height: 400,
+      height: 330,
       type: 'area',
       toolbar: {show: !isMaxWidth500px()},
     },
@@ -115,6 +120,7 @@ function loadGlucoseReadingsByUserId(startDate, endDate) {
             }
           });
           updateSearchDateRange(glucoseReadingDateLabels);
+          updateStatisticsPanel(glucoseValues);
           break;
 
         case HTTP_NOT_FOUND:
@@ -146,6 +152,56 @@ function loadGlucoseReadingsByUserId(startDate, endDate) {
     }
   };
   sendGETToGlucose(xmlhttp, startDate, endDate);
+}
+
+/**
+ * Update Statistics panel.
+ * @param {Array} glucoseValues
+ * @param {Array} glucoseReadingDateLabels
+ */
+function updateStatisticsPanel(glucoseValues) {
+  averageValue.innerText = calcAverage(glucoseValues);
+  deviationValue.innerText = calculateStandardDeviation(glucoseValues);
+
+  const {hypo, hyper} = countHypoAndHyper(glucoseValues);
+  hyposValue.innerText = hypo;
+  hypersValue.innerText = hyper;
+}
+
+/**
+ * @param {Array} values
+ * @return {object}
+ */
+function countHypoAndHyper(values) {
+  const hypo = values.filter((valor) => valor <= HYPOGLYCEMIA).length;
+  const hyper = values.filter((valor) => valor >= HYPERGLYCEMIA).length;
+  return {hypo, hyper};
+}
+
+/**
+ * @param {Array} values
+ * @return {Number} The average.
+ */
+function calcAverage(values) {
+  const sum = values.reduce((acc, valor) => acc + valor, 0);
+  const average = sum / values.length;
+  return Math.round(average);
+}
+
+/**
+ * The function calculates he standard deviation of a given array of numbers.
+ * @param {Array} values An array of blood glucose numbers.
+ * @return {Number} The standard deviation value.
+ */
+function calculateStandardDeviation(values) {
+  const n = values.length;
+  if (n > 1) {
+    const mean = values.reduce((acc, val) => acc + val, 0) / n;
+    const squaredDifferencesSum = values.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0);
+    const standardDeviation = Math.sqrt(squaredDifferencesSum / (n - 1));
+    return Math.round(standardDeviation);
+  }
+  return 0;
 }
 
 /**

--- a/src/public/includes/js/home.js
+++ b/src/public/includes/js/home.js
@@ -9,7 +9,7 @@ const deviationValue = document.getElementById('deviation-value');
 const hyposValue = document.getElementById('hypos-value');
 const hypersValue = document.getElementById('hypers-value');
 
-// eslint-disable-next-line no-var
+// eslint-disable-next-line no-var, no-unused-vars
 var glucoseReadingsChart;
 // eslint-disable-next-line prefer-const
 let glucoseValues = [];
@@ -31,8 +31,23 @@ const XMLHTTPREQUEST_STATUS_DONE = 4;
  */
 function loadChart() {
   const chartConfiguration = getChartConfiguration();
+
+  // Validate chart context and configuration
+  if (!chartContext || !chartConfiguration) {
+    console.error('Chart context or configuration is missing. Cannot render the chart.');
+    return;
+  }
+
+  // Destroy existing chart if it exists to avoid memory leaks
+  if (this.glucoseReadingsChart) {
+    this.glucoseReadingsChart.destroy();
+  }
+
+  // Create and render the new chart
   this.glucoseReadingsChart = new ApexCharts(chartContext, chartConfiguration);
-  this.glucoseReadingsChart.render();
+  this.glucoseReadingsChart.render().catch((error) => {
+    console.error('Failed to render chart:', error);
+  });
 }
 
 /**
@@ -43,7 +58,6 @@ function getChartConfiguration() {
   return {
     series: [
       {
-        name: 'Glycemia',
         data: glucoseValues,
       },
     ],
@@ -174,9 +188,13 @@ function updateStatisticsPanel(glucoseValues) {
  *                 of the `searchDateRange` element directly.
  */
 function updateSearchDateRange(glucoseReadingDateLabels) {
+  if (!glucoseReadingDateLabels || glucoseReadingDateLabels.length === 0) {
+    searchDateRange.innerText = ' ';
+    return;
+  }
   startDate = glucoseReadingDateLabels[0].split(' ')[0];
   endDate = glucoseReadingDateLabels[glucoseReadingDateLabels.length - 1].split(' ')[0];
-  searchDateRange.innerText = `${startDate}-${endDate}`;
+  searchDateRange.innerText = startDate === endDate ? startDate : `${startDate} - ${endDate}`;
 }
 
 /**
@@ -227,6 +245,11 @@ function adaptLabelDate(value) {
  * It makes the chart panel visible at the center of the screen.
  */
 function makeChartPanelVisible() {
+  // Validate chart context and configuration
+  if (!chartContext || !getChartConfiguration()) {
+    console.error('Chart context or configuration is missing. Cannot render the chart.');
+    return;
+  }
   panelWelcomeCenter.classList.add('invisible');
   panelChart.classList.remove('invisible');
 }

--- a/src/public/includes/js/home.js
+++ b/src/public/includes/js/home.js
@@ -160,48 +160,10 @@ function loadGlucoseReadingsByUserId(startDate, endDate) {
  * @param {Array} glucoseReadingDateLabels
  */
 function updateStatisticsPanel(glucoseValues) {
-  averageValue.innerText = calcAverage(glucoseValues);
+  averageValue.innerText = calculateAverage(glucoseValues);
   deviationValue.innerText = calculateStandardDeviation(glucoseValues);
-
-  const {hypo, hyper} = countHypoAndHyper(glucoseValues);
-  hyposValue.innerText = hypo;
-  hypersValue.innerText = hyper;
-}
-
-/**
- * @param {Array} values
- * @return {object}
- */
-function countHypoAndHyper(values) {
-  const hypo = values.filter((valor) => valor <= HYPOGLYCEMIA).length;
-  const hyper = values.filter((valor) => valor >= HYPERGLYCEMIA).length;
-  return {hypo, hyper};
-}
-
-/**
- * @param {Array} values
- * @return {Number} The average.
- */
-function calcAverage(values) {
-  const sum = values.reduce((acc, valor) => acc + valor, 0);
-  const average = sum / values.length;
-  return Math.round(average);
-}
-
-/**
- * The function calculates he standard deviation of a given array of numbers.
- * @param {Array} values An array of blood glucose numbers.
- * @return {Number} The standard deviation value.
- */
-function calculateStandardDeviation(values) {
-  const n = values.length;
-  if (n > 1) {
-    const mean = values.reduce((acc, val) => acc + val, 0) / n;
-    const squaredDifferencesSum = values.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0);
-    const standardDeviation = Math.sqrt(squaredDifferencesSum / (n - 1));
-    return Math.round(standardDeviation);
-  }
-  return 0;
+  hyposValue.innerText = getHypoglycemiaCount(glucoseValues, HYPOGLYCEMIA);
+  hypersValue.innerText = getHyperglycemiaCount(glucoseValues, HYPERGLYCEMIA);
 }
 
 /**

--- a/src/public/includes/js/newEntry.js
+++ b/src/public/includes/js/newEntry.js
@@ -97,7 +97,7 @@ function prepareJsonNewEntry() {
     glucose: fieldGlucose.value,
     total_carbs: getTotalCarbs(),
     dateTime: fieldDate.value,
-    id_markermeal: fieldMarkermeal.selectedIndex,
+    id_markermeal: fieldMarkermeal.value,
     id_measurement_unity: getMeasurementUnity(),
   });
 }

--- a/src/public/includes/js/newEntry.js
+++ b/src/public/includes/js/newEntry.js
@@ -71,8 +71,8 @@ function sendPOSTToGlucose(xmlhttp) {
 
   if (!token || !userId) logOut();
 
-  xmlhttp.open('POST', API_BASE_REQUEST+`/diary/users/${userId}`);
-  xmlhttp.setRequestHeader('Authorization', 'Bearer '+token);
+  xmlhttp.open('POST', API_BASE_REQUEST + `/diary/users/${userId}`);
+  xmlhttp.setRequestHeader('Authorization', 'Bearer ' + token);
   xmlhttp.setRequestHeader('Content-type', 'application/json; charset=utf-8');
   xmlhttp.send(jsonNewEntry);
 }
@@ -143,12 +143,11 @@ function resetChart() {
 }
 
 /**
- * Destroy the chart to run its update.
+ * Destroys the glucose readings chart if it exists and
+ * clears all associated data arrays.
  */
 function destroyChart() {
-  if (glucoseReadingsChart != null) {
-    glucoseReadingsChart.destroy();
-  }
+  if (glucoseReadingsChart) glucoseReadingsChart.destroy();
   glucoseValues = [];
   glucoseReadingDateLabels = [];
   hyperglycemiaValues = [];
@@ -175,8 +174,8 @@ fieldFood.addEventListener('keypress', (e) => {
  * e.g. "1 cup of milk", "2 slices of cheese".
  */
 async function addNewListItem(food) {
-  const url = API_BASE_REQUEST+`/carbscounting/${food}`;
-  const myHeaders = new Headers({'Authorization': 'Bearer '+getJwtToken()});
+  const url = API_BASE_REQUEST + `/carbscounting/${food}`;
+  const myHeaders = new Headers({Authorization: 'Bearer ' + getJwtToken()});
   const myInit = {method: 'GET', headers: myHeaders};
   const response = await fetch(url, myInit);
 

--- a/src/public/includes/js/statistics.js
+++ b/src/public/includes/js/statistics.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable max-len */
+
+/**
+ * Calculate the average of an array of numbers, rounded to the nearest integer.
+ * @param {Array<number>} values - An array of numeric values.
+ * @return {number} The average of the values, rounded to the nearest integer.
+ */
+function calculateAverage(values) {
+  const sum = values.reduce((acc, valor) => acc + valor, 0);
+  const average = sum / values.length;
+  return Math.round(average);
+}
+
+/**
+ * The function calculates he standard deviation of a given array of numbers.
+ * @param {Array} values An array of blood glucose numbers.
+ * @return {Number} The standard deviation value.
+ */
+function calculateStandardDeviation(values) {
+  const n = values.length;
+  if (n > 1) {
+    const mean = values.reduce((acc, val) => acc + val, 0) / n;
+    const squaredDifferencesSum = values.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0);
+    const standardDeviation = Math.sqrt(squaredDifferencesSum / (n - 1));
+    return Math.round(standardDeviation);
+  }
+  return 0;
+}
+
+/**
+ * Calculate the number of hypoglycemic values in the array.
+ * @param {Array<number>} values - An array of numeric glucose values.
+ * @param {number} hypoglycemiaThreshold - The threshold value for hypoglycemia.
+ * @return {number} The count of values less than or equal to the hypoglycemia threshold.
+ */
+function getHypoglycemiaCount(values, hypoglycemiaThreshold) {
+  return values.filter((value) => value <= hypoglycemiaThreshold).length;
+}
+
+/**
+ * Calculate the number of hyperglycemic values in the array.
+ * @param {Array<number>} values - An array of numeric glucose values.
+ * @param {number} hyperglycemiaThreshold - The threshold value for hyperglycemia.
+ * @return {number} The count of values greater than or equal to the hyperglycemia threshold.
+ */
+function getHyperglycemiaCount(values, hyperglycemiaThreshold) {
+  return values.filter((value) => value >= hyperglycemiaThreshold).length;
+}

--- a/src/public/includes/js/statistics.js
+++ b/src/public/includes/js/statistics.js
@@ -47,3 +47,54 @@ function getHypoglycemiaCount(values, hypoglycemiaThreshold) {
 function getHyperglycemiaCount(values, hyperglycemiaThreshold) {
   return values.filter((value) => value >= hyperglycemiaThreshold).length;
 }
+
+/**
+ * Calculates the percentage of hypoglycemic readings in an array of glucose values.
+ *
+ * @param {Array<number>} glucoseValues - An array of glucose readings.
+ * @param {number} hypoglycemiaThreshold - The threshold value for hypoglycemia.
+ * @return {number} The percentage of readings below or equal to the hypoglycemia threshold.
+ */
+function calculateHypoglycemiaPercentage(glucoseValues, hypoglycemiaThreshold) {
+  const hypoglycemiaCount = glucoseValues.filter((value) => value <= hypoglycemiaThreshold).length;
+  return calculateRoundedUpPercentage(hypoglycemiaCount, glucoseValues.length);
+}
+
+/**
+ * Calculates the percentage of hyperglycemic readings in an array of glucose values.
+ *
+ * @param {Array<number>} glucoseValues - An array of glucose readings.
+ * @param {number} hyperglycemiaThreshold - The threshold value for hyperglycemia.
+ * @return {number} The percentage of readings above or equal to the hyperglycemia threshold.
+ */
+function calculateHyperglycemiaPercentage(glucoseValues, hyperglycemiaThreshold) {
+  const hyperglycemiaCount = glucoseValues.filter((value) => value >= hyperglycemiaThreshold).length;
+  return calculateRoundedUpPercentage(hyperglycemiaCount, glucoseValues.length);
+}
+
+/**
+ * Calculates the percentage of normal glucose readings in an array of glucose values.
+ * A normal reading is defined as a value that falls between the hypoglycemia and hyperglycemia thresholds.
+ *
+ * @param {Array<number>} glucoseValues - An array of glucose readings.
+ * @param {number} hypoglycemiaThreshold - The threshold value for hypoglycemia.
+ * @param {number} hyperglycemiaThreshold - The threshold value for hyperglycemia.
+ * @return {number} The percentage of readings that are within the normal range (greater than the hypoglycemia threshold and less than the hyperglycemia threshold).
+ */
+function calculateNormalGlycemiaPercentage(glucoseValues, hypoglycemiaThreshold, hyperglycemiaThreshold) {
+  const normalCount = glucoseValues.filter((value) => value > hypoglycemiaThreshold && value < hyperglycemiaThreshold).length;
+  return calculateRoundedUpPercentage(normalCount, glucoseValues.length);
+}
+
+/**
+ * Calculates the percentage of values that meet a certain condition and rounds it up to the nearest integer.
+ *
+ * @param {number} count - The number of values that meet the condition.
+ * @param {number} total - The total number of values.
+ * @return {number} The percentage of values meeting the condition, rounded up to the nearest integer.
+ */
+function calculateRoundedUpPercentage(count, total) {
+  if (total === 0) return 0; // Avoid division by zero
+  const percentage = (count / total) * 100;
+  return Math.ceil(percentage);
+}

--- a/src/public/includes/styles/dashboard.css
+++ b/src/public/includes/styles/dashboard.css
@@ -237,6 +237,85 @@ body {
   border-radius: 50px;
 }
 
+/************************* 
+ Panel Statistics
+ *************************/
+.statistics-panel{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  padding: 0 10px 30px 0;
+}
+.statistics-card {
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  flex: 1 1 20%;
+  font-family: "Poppins", sans-serif;
+}
+.statistics-card-header {
+  display: flex;
+  align-items: center;
+  color: #7a7a7a;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+.statistics-card-icon {
+  font-size: 18px;
+  margin-right: 8px;
+}
+.statistics-card-title {
+  font-weight: 600;
+  color: #012970;
+}
+.statistics-card-content {
+  display: flex;
+  align-items: center;
+  justify-content: end;
+  font-size: 26px;
+  color: #333;
+}
+.statistics-card-dot {
+  width: 8px;
+  height: 8px;
+  background-color: green;
+  border-radius: 50%;
+  margin-right: 8px;
+}
+.statistics-card-value {
+  font-weight: bold;
+}
+.statistics-card-unit {
+  font-size: 14px;
+  color: #7a7a7a;
+  margin-left: 4px;
+}
+.statistics-card-footer {
+  display: flex;
+  font-size: 14px;
+  color: #7a7a7a;
+  margin-top: 8px;
+  justify-content: end;
+}
+.statistics-card-footer-text {
+  margin-right: 4px;
+}
+.statistics-card-footer-value {
+  color: green;
+  font-weight: bold;
+}
+
+@media (max-width: 500px) {
+  .statistics-panel {
+    flex-direction: column;
+  }
+  .statistics-card{
+    flex: 1 1 100%;
+  }
+}
+/**********************************/
+
 @media (max-width: 500px) {
   .header-visibility {
     display: flex;


### PR DESCRIPTION
### Problem
- Currently, the Glicocheck dashboard lacks a consolidated view of essential blood sugar metrics, which would be beneficial for users to monitor and manage their health. Users must manually check individual readings, which makes it challenging to understand overall trends or see a summary of their recent data.

### Solution
This PR introduces a "Statistics" panel on the Glicocheck dashboard, providing users with a comprehensive overview of key blood sugar metrics and trends. The panel includes the following:
- Cards for Key Metrics:
  - Average Blood Sugar: Displays the average blood sugar level.
  - Blood Sugar Deviation: Shows the standard deviation to indicate variability.
  - Total Hypoglycemic Events (Hypos): Counts occurrences of blood sugar levels below 70 mg/dL.
  - Total Hyperglycemic Events (Hypers): Counts occurrences of blood sugar levels above 160 mg/dL.

### How To Test
1. Access the Dashboard:
   - Log in to the Glicocheck app and navigate to the dashboard.
2. Verify the Statistics Panel:
   - Ensure a new "Statistics" panel is visible on the dashboard.

### Fixes 
- #63 