### PR TITLE
Display filter options inline outside of calendar icon for enhanced accessibility

### DIFF
--- a/src/public/home.html
+++ b/src/public/home.html
@@ -123,6 +123,13 @@
                       <div class="filter-item" onclick="updateDataByPeriods('chart', 1, 'months')" >1 month</div>
                       <div class="filter-item" onclick="updateDataByPeriods('chart', 2, 'months')" >2 months</div>
                       <div class="filter-item" onclick="updateDataByPeriods('chart', 3, 'months')" >3 months</div>
+
+                      <button type="button" class="icon me-2 btn btn-sm btn-outline-secondary"
+                        title="Set custom period"
+                        data-bs-toggle="modal"
+                        data-bs-target="#modalCalendar">
+                        <span data-feather="calendar" class="align-text-bottom"></span>
+                      </button>
                     </div>
                     <div class="filter-calendar me-3">
                       <a class="icon" href="#" data-bs-toggle="dropdown">                      
@@ -253,7 +260,10 @@
 
           <!-- ADD GLYCEMIA LOG -->
           <button type="button" class="mb-2 me-2 btn btn-sm btn-primary add-entry" 
-            data-bs-toggle="modal" data-bs-target="#modalNewEntry" id="btnAddGlycemiaLog">
+            data-bs-toggle="modal"
+            title="Add new glycemia reading"
+            data-bs-target="#modalNewEntry" 
+            id="btnAddGlycemiaLog">
             <span data-feather="plus" class="align-text-bottom"></span>
           </button>
         </main>

--- a/src/public/home.html
+++ b/src/public/home.html
@@ -113,26 +113,33 @@
           <div id="panel-chart" class="invisible">
             <div class="card mb-3">
               <div class="card-body">                
-                <div class="justify-content">
+                <div class="d-flex justify-content-between">
                   <h5 class="card-title"><span class="ms-2" id="search_date_range"></span></h5>
 
-                  <div class="filter me-3">
-                    <!-- BUTTON FILTER -->
-                    <a class="icon" href="#" data-bs-toggle="dropdown">                      
-                    <button type="button" class="me-2 btn btn-sm btn-outline-secondary">
-                      <span data-feather="calendar" class="align-text-bottom"></span>
-                    </button>
-  
-                    <!-- FILTER BY PERIODS -->
-                    <ul class="dropdown-menu">
-                      <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 0, 'weeks')">Today</a></li>
-                      <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 1, 'weeks')">1 week</a></li>
-                      <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 1, 'months')">1 month</a></li>
-                      <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 2, 'months')">2 months</a></li>
-                      <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 3, 'months')">3 months</a></li>
-                      <li><hr class="dropdown-divider"></li>
-                      <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#modalCalendar" href="#">Custom</a></li>
-                    </ul>
+                  <div class="filter-container">
+                    <div class="filter-options">
+                      <div class="filter-item" onclick="updateDataByPeriods('chart', 0, 'weeks')" >Today</div>
+                      <div class="filter-item selected" onclick="updateDataByPeriods('chart', 1, 'weeks')" >1 week</div>
+                      <div class="filter-item" onclick="updateDataByPeriods('chart', 1, 'months')" >1 month</div>
+                      <div class="filter-item" onclick="updateDataByPeriods('chart', 2, 'months')" >2 months</div>
+                      <div class="filter-item" onclick="updateDataByPeriods('chart', 3, 'months')" >3 months</div>
+                    </div>
+                    <div class="filter-calendar me-3">
+                      <a class="icon" href="#" data-bs-toggle="dropdown">                      
+                      <button type="button" class="me-2 btn btn-sm btn-outline-secondary">
+                        <span data-feather="calendar" class="align-text-bottom"></span>
+                      </button>
+    
+                      <ul class="dropdown-menu">
+                        <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 0, 'weeks')">Today</a></li>
+                        <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 1, 'weeks')">1 week</a></li>
+                        <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 1, 'months')">1 month</a></li>
+                        <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 2, 'months')">2 months</a></li>
+                        <li><a class="dropdown-item" onclick="updateDataByPeriods('chart', 3, 'months')">3 months</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#modalCalendar" href="#">Custom</a></li>
+                      </ul>
+                    </div>
                   </div>
                 </div>
                 

--- a/src/public/includes/js/home.js
+++ b/src/public/includes/js/home.js
@@ -328,6 +328,21 @@ function getDateRangeByNumberOfWeeks(numOfWeeks) {
   return [formatDate(startDate), formatDate(endDate)];
 }
 
+/**
+ * Adds event listeners to filter items to apply the 'selected' class
+ * when clicked and remove it from other items.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  const filterItems = document.querySelectorAll('.filter-options .filter-item');
+
+  filterItems.forEach((item) => {
+    item.addEventListener('click', () => {
+      filterItems.forEach((i) => i.classList.remove('selected'));
+      item.classList.add('selected');
+    });
+  });
+});
+
 const [start, end] = getDateRangeByNumberOfWeeks(1);
 dateContext ={
   startDate: start,

--- a/src/public/includes/styles/dashboard.css
+++ b/src/public/includes/styles/dashboard.css
@@ -5,6 +5,9 @@
   --sidebar-secondary-color: #80c3ef;
   --default-background-color: #f6f9ff;
   --menuitem-background-color: #f6f6f6;
+  --chart-filter-item-selected-color: #007bff;
+  --chart-filter-item-selected-background: #e9f1fa;
+  --chart-filter-item-border-radius: 30%;
 }
 
 * {
@@ -46,10 +49,9 @@ body {
   margin-left: 3px;
 }
 
-/*
+/********************************
  * Sidebar
- */
-
+ ********************************/
 .sidebar {
   position: fixed;
   top: 0;
@@ -85,10 +87,9 @@ body {
   color: var(--menuitem-background-color);
 }
 
-/*
+/********************************
  * Navbar
- */
-
+ ********************************/
 .navbar-brand {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
@@ -126,9 +127,9 @@ body {
   justify-content: flex-end;
 }
 
-/*
+/*******************************
  * Chart
- */
+ *******************************/
 .visible {
   display: block;
 }
@@ -141,9 +142,9 @@ body {
   display: none;
 }
 
-/*
+/********************************
 * Welcome center
-*/
+********************************/
 #welcome-center {
   display: block;
   padding-top: 25vh;
@@ -186,24 +187,48 @@ body {
   background: #dee2e6;
 }
 
-.dropdown-item {
-  cursor: pointer;
-}
-
 .nav-item {
   padding: 1px;
 }
 
-.filter {
+/**********************************
+  FILTER CHART
+***********************************/
+.filter-calendar {
+  display: none;
   position: absolute;
   padding: 10px 0 0 0;
   right: 0px;
   top: 15px;
 }
 
-.filter .icon {
-  color: #aab7cf;
-  transition: 0.3s;
+.filter-container {
+  display: flex;
+  align-items: center;
+}
+
+.filter-options {
+  display: flex;
+  gap: 8px;
+}
+
+.filter-item {
+  font-size: 15px;
+  color: #555;
+  cursor: pointer;
+  padding: 8px;
+}
+
+.filter-item:hover {
+  background-color: var(--chart-filter-item-selected-background);
+  border-radius: var(--chart-filter-item-border-radius);  
+}
+
+.filter-item.selected {
+  color: var(--chart-filter-item-selected-color);
+  font-weight: bold;
+  background-color: var(--chart-filter-item-selected-background);
+  border-radius: var(--chart-filter-item-border-radius); 
 }
 
 .card-title {
@@ -237,9 +262,9 @@ body {
   border-radius: 50px;
 }
 
-/************************* 
+/******************************* 
  Panel Statistics
- *************************/
+ *******************************/
 .statistics-panel{
   display: flex;
   flex-wrap: wrap;
@@ -344,6 +369,15 @@ body {
   }
   .scrollablePanel {
     max-height: 150px;
+  }  
+}
+
+@media (max-width: 600px) {
+  .filter-options {
+    display: none;
+  }
+  .filter-calendar {
+    display: block;
   }
 }
 

--- a/src/public/includes/styles/dashboard.css
+++ b/src/public/includes/styles/dashboard.css
@@ -192,8 +192,12 @@ body {
 }
 
 /**********************************
-  FILTER CHART
+  CHART FILTER
 ***********************************/
+.icon:hover{
+  color: var(--chart-filter-item-selected-background);
+}
+
 .filter-calendar {
   display: none;
   position: absolute;
@@ -372,7 +376,7 @@ body {
   }  
 }
 
-@media (max-width: 600px) {
+@media (max-width: 700px) {
   .filter-options {
     display: none;
   }


### PR DESCRIPTION
### Problem
- The current UI design for filtering data requires users to interact with a calendar icon to access the filter options. This extra step decreases accessibility and impacts user experience as the options are not immediately visible.

### Solution
- This PR extracts the filter options from the dropdown list triggered by the calendar icon and places them in a dedicated `div` that is displayed inline on the dashboard. This change makes the filter options always visible, improving accessibility and usability.

### How To Test

1. Pull the branch and run the project locally.
2. Navigate to the home page (dashboard) where the filter options are displayed.
3. Verify that the filter options are now visible inline without needing to click the calendar icon.
4. Click on each filter option and confirm that the chart updates correctly based on the selected option.
5. Test the responsiveness by resizing the browser window and ensuring that the filter options are still accessible and displayed properly.
6. Ensure all existing filtering functionality remains intact and operational.

### Fixes 
- #72 